### PR TITLE
Corrected quoutation for certificate

### DIFF
--- a/ScreenRecording-All-Known-Test-Profile.mobileconfig
+++ b/ScreenRecording-All-Known-Test-Profile.mobileconfig
@@ -457,7 +457,7 @@
 						<key>Authorization</key>
 						<string>AllowStandardUserToSetSystemService</string>
 						<key>CodeRequirement</key>
-						<string>anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = 83S2TRZ3CS</string>
+						<string>anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "83S2TRZ3CS"</string>
 						<key>Comment</key>
 						<string>filewave-vnc-server</string>
 						<key>Identifier</key>


### PR DESCRIPTION
Sorry for the inconvenience. Missed the quotations, which needed to be there according to my test client.