### PR TITLE
Add WS1 Assist

### DIFF
--- a/ScreenRecording-All-Known-Test-Profile.mobileconfig
+++ b/ScreenRecording-All-Known-Test-Profile.mobileconfig
@@ -645,6 +645,18 @@
 						<key>IdentifierType</key>
 						<string>bundleID</string>
 					</dict>
+					<dict>
+						<key>Authorization</key>
+						<string>AllowStandardUserToSetSystemService</string>
+						<key>CodeRequirement</key>
+						<string>identifier "com.aetherpal.mac.remotecontrol" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = V4Y7PP8KCJ</string>
+						<key>Comment</key>
+						<string>Workspace ONE Assist</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>Identifier</key>
+						<string>com.aetherpal.mac.remotecontrol</string>
+					</dict>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
[Product Page](https://www.vmware.com/products/workspace-one/workspaceone-assist.html)

Matches vendor documentation, too:

https://docs.vmware.com/en/VMware-Workspace-ONE-UEM/services/rn/Workspace-ONE-Assist-for-macOS.html