### PR TITLE
Added Brave Browser

### DIFF
--- a/ScreenRecording-All-Known-Test-Profile.mobileconfig
+++ b/ScreenRecording-All-Known-Test-Profile.mobileconfig
@@ -837,6 +837,18 @@
 						<key>IdentifierType</key>
 						<string>bundleID</string>
 					</dict>
+					<dict>
+						<key>Authorization</key>
+						<string>AllowStandardUserToSetSystemService</string>
+						<key>CodeRequirement</key>
+						<string>identifier "com.brave.Browser" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */</string>
+						<key>Comment</key>
+						<string>Brave Browser</string>
+						<key>Identifier</key>
+						<string>com.brave.Browser</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Brave browser does not appear to have a certificate leaf associated with it, but we use Brave Browser as an alternative to Chrome in our environment.