### PR TITLE
Fix incorrect CodeRequirement identifier for RustDesk

### DIFF
--- a/ScreenRecording-All-Known-Test-Profile.mobileconfig
+++ b/ScreenRecording-All-Known-Test-Profile.mobileconfig
@@ -865,7 +865,7 @@
 						<key>Authorization</key>
 						<string>AllowStandardUserToSetSystemService</string>
 						<key>CodeRequirement</key>
-						<string>identifier rustdesk and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HZF9JMC8YN</string>
+						<string>identifier "com.carriez.rustdesk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HZF9JMC8YN</string>
 						<key>Comment</key>
 						<string>RustDesk</string>
 						<key>Identifier</key>


### PR DESCRIPTION
After a bit of troubleshooting why remote support on our mac workstations didn't work I figured out, that the identifier for RustDesk in this profile template is incorrect/outdated. 

This is the correct identifier for the current version (`1.3.1` at the time of writing). 

```
user@mac ~ % codesign --display -r - /Applications/RustDesk.app 
Executable=/Applications/RustDesk.app/Contents/MacOS/RustDesk
designated => identifier "com.carriez.rustdesk" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HZF9JMC8YN
```