### PR TITLE
Add entry for Adobe Illustrator

### DIFF
--- a/ScreenRecording-All-Known-Test-Profile.mobileconfig
+++ b/ScreenRecording-All-Known-Test-Profile.mobileconfig
@@ -957,6 +957,18 @@
 						<key>IdentifierType</key>
 						<string>bundleID</string>
 					</dict>
+					<dict>
+						<key>Authorization</key>
+						<string>AllowStandardUserToSetSystemService</string>
+						<key>CodeRequirement</key>
+						<string>anchor apple generic and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JQ525L2MZD)</string>
+						<key>Comment</key>
+						<string>Adobe Illustrator</string>
+						<key>Identifier</key>
+						<string>com.adobe.illustrator</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
 			  </array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Adds an entry for Adobe Illustrator. Illustrator requests screen recording permission to allow the eyedropper tool to work outside of the Illustrator application.